### PR TITLE
fix name of package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ https://kenhino.github.io/Discvar/
     ```
 
 ### For developing
-- we recommend install `pompon` from source using [`uv`](https://docs.astral.sh/uv/)
+- we recommend install `discvar` from source using [`uv`](https://docs.astral.sh/uv/)
 
     ```bash
     $ git clone https://github.com/KenHino/Discvar.git
@@ -42,9 +42,9 @@ https://kenhino.github.io/Discvar/
     ```
     or
     ```bash
-    $ souce .venv/bin/activate
+    $ source .venv/bin/activate
     $ python
-    >>> import pompon
+    >>> import discvar
     ```
 
     For jupyter notebook tutorials, you can use


### PR DESCRIPTION
Summary
- Fixed incorrect references to `pompon` in the README
- Updated them to `discvar`
- Fixed minor typos

Changes
- Replaced all occurrences of `pompon` with `discvar`
- Fixed a typo in the `source` command

Details

- Some references to the unrelated package `pompon` were mistakenly included in the README.
These have been corrected to ensure consistency with the current repository and usage.