### PR TITLE
Symmetrize HO-DVR grid & fix type annotation in abc.py

### DIFF
--- a/discvar/abc.py
+++ b/discvar/abc.py
@@ -1,6 +1,6 @@
 import functools
 from abc import ABC, abstractmethod
-from typing import Any, Callable
+from typing import Callable
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -50,7 +50,7 @@ class DVRPrimitivesMixin(ABC):
 
         """
         if not hasattr(self, "pos_rep_matrix"):
-            self.pos_rep_matrix: np.ndarray[Any, np.dtype[np.bool_]] = np.zeros(
+            self.pos_rep_matrix: np.ndarray = np.zeros(
                 (self.ngrid, self.ngrid), dtype=np.complex128
             )
             avg_error = 0.0

--- a/discvar/ho.py
+++ b/discvar/ho.py
@@ -186,7 +186,11 @@ class HarmonicOscillator(DVRPrimitivesMixin):
 
     def diagnalize_pos_rep_matrix(self):
         """Analytical formulation has not yet derived."""
-        return super().diagnalize_pos_rep_matrix()
+        super().diagnalize_pos_rep_matrix()
+
+        rel = np.asarray(self.grids, dtype=float) - self.q_eq
+        rel = 0.5 * (rel - rel[::-1])
+        self.grids = list(self.q_eq + rel)
 
     def get_ovi_CS_HO(
         self, p: float, q: float, type: str = "DVR"


### PR DESCRIPTION
- discvar/abc.py
Fixed the type annotation of ```self.pos_rep_matrix```. Previously, ```self.pos_rep_matrix``` was annotated as ```self.pos_rep_matrix: np.ndarray[Any, np.dtype[np.bool_]]```. However, ```self.pos_rep_matrix``` stores floating-point or complex-valued data.
This change is needed to pass ```mypy``` in pre-commit.
Relevant error in pre-commit (```mypy```):
```
mypy.....................................................................Failed
- hook id: typecheck
- exit code: 1

discvar/sin.py:120: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[float64]]", variable has type "ndarray[Any, dtype[numpy.bool[builtins.bool]]]")  [assignment]
Found 1 error in 1 file (checked 7 source files)
```

- discvar/ho.py
Symmetrize ```self.grids``` in ```HarmonicOscillator```. In particular, when the number of grids is odd, the center grid point is now set exactly to zero.
This change passes pre-commit, but its impact on methods such as ```get_sqrt_weights``` has not been verified.